### PR TITLE
PR automation and repo/workflow-hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @justeat/statsd
+* @justeattakeaway/statsd

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Feature requests and bugs
 
-Please submit any feature requests or bugs as an [issue](https://github.com/justeat/JustEat.StatsD/issues) in GitHub.
+Please submit any feature requests or bugs as an [issue](https://github.com/justeattakeaway/JustEat.StatsD/issues) in GitHub.
 
 ## Pull requests
 
@@ -10,16 +10,16 @@ The easier your PRs are to review and merge, the more likely your contribution w
 
 If you wish to contribute code, please consider the guidelines below:
 
-  1. Create an issue detailing the motivation for the change.
-  1. Fork the repository to your GitHub account.
-  1. Create a branch to work on your changes.
-  1. Try to commit changes in a logical manner. Messy histories will be squashed if merged.
-  1. Please follow the existing code style and [EditorConfig](http://editorconfig.org/) formatting settings so that your file touches are consistent with ours and the diff is reduced.
-  1. If fixing a bug or adding new functionality, add any tests you deem appropriate.
-  1. Test coverage should not go down.
-  1. Note any breaking changes in your PR description.
-  1. Ensure `build.ps1` runs with no errors or warnings and all the tests pass.
-  1. Open a pull request against the `main` branch, referencing your issue, if appropriate.
+1. Create an issue detailing the motivation for the change.
+1. Fork the repository to your GitHub account.
+1. Create a branch to work on your changes.
+1. Try to commit changes in a logical manner. Messy histories will be squashed if merged.
+1. Please follow the existing code style and [EditorConfig](http://editorconfig.org/) formatting settings so that your file touches are consistent with ours and the diff is reduced.
+1. If fixing a bug or adding new functionality, add any tests you deem appropriate.
+1. Test coverage should not go down.
+1. Note any breaking changes in your PR description.
+1. Ensure `build.ps1` runs with no errors or warnings and all the tests pass.
+1. Open a pull request against the `main` branch, referencing your issue, if appropriate.
 
 Once your pull request is opened, the project maintainers will assess it for validity and an appropriate level of quality. For example, the Pull Request status checks should all be green.
 
@@ -27,10 +27,10 @@ If the project maintainers are satisfied that your contribution is appropriate i
 
 ## Releases
 
-  * Check the version number has been updated since the last release - follow [SemVer rules](http://semver.org)
-    * Bump the version in `version.props` if neccessary.
-  * Update the CHANGELOG.md
-  * Create a new release in [GitHub](https://github.com/justeat/JustEat.StatsD/releases) with appropriate release notes and tagged version number (for example `v1.2.3`).
-  * A build will run for the tag in GitHub Actions and publish the package to [NuGet](https://www.nuget.org/packages/JustEat.StatsD).
-  * Wait for NuGet.org to index the package.
-  * Share the news! 🎉
+* Check the version number has been updated since the last release - follow [SemVer rules](http://semver.org)
+  * Bump the version in `version.props` if neccessary.
+* Update the CHANGELOG.md
+* Create a new release in [GitHub](https://github.com/justeattakeaway/JustEat.StatsD/releases) with appropriate release notes and tagged version number (for example `v1.2.3`).
+* A build will run for the tag in GitHub Actions and publish the package to [NuGet](https://www.nuget.org/packages/JustEat.StatsD).
+* Wait for NuGet.org to index the package.
+* Share the news! 🎉

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "05:30"
     timezone: Europe/London
   reviewers:
-    - "justeat/statsd"
+    - "justeattakeaway/statsd"
 - package-ecosystem: nuget
   directory: "/"
   schedule:
@@ -15,12 +15,10 @@ updates:
     time: "05:30"
     timezone: Europe/London
   reviewers:
-    - "justeat/statsd"
+    - "justeattakeaway/statsd"
   open-pull-requests-limit: 10
   ignore:
-  - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
-    versions:
-    - "> 2.0.0"
-  - dependency-name: System.Memory
-    versions:
-    - "> 4.5.1, < 4.6"
+    - dependency-name: "Microsoft.Extensions.DependencyInjection"
+      update-types: ["version-update:semver-minor"]
+    - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
+    - dependency-name: System.Memory

--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -1,0 +1,160 @@
+name: approve-and-merge
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  REVIEWER_LOGIN: ${{ vars.REVIEWER_USER_NAME }}
+
+permissions:
+  contents: read
+
+jobs:
+  review-pull-request:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == vars.UPDATER_COMMIT_USER_NAME }}
+
+    steps:
+
+    - name: Generate GitHub application token
+      id: generate-application-token
+      uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      with:
+        application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+        application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+        permissions: "contents:write, pull_requests:write"
+
+    - name: Install powershell-yaml
+      shell: pwsh
+      run: Install-Module -Name powershell-yaml -Force -MaximumVersion "0.4.7"
+
+    - name: Check which dependencies were updated
+      id: check-dependencies
+      env:
+        # This list of trusted package prefixes needs to stay in sync with include-nuget-packages in the update-dotnet-sdk workflow.
+        INCLUDE_NUGET_PACKAGES: "Microsoft.AspNetCore.,Microsoft.NET.Test.Sdk"
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+      shell: pwsh
+      run: |
+        # Replicate the logic in the dependabot/fetch-metadata action.
+        # See https://github.com/dependabot/fetch-metadata/blob/aea2135c95039f05c64436f1d14638c300e10b2b/src/dependabot/update_metadata.ts#L29-L68.
+        # Query the GitHub API to get the commits in the pull request.
+        $commits = gh api `
+          /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits `
+          --jq '.[] | { author: .author.login, message: .commit.message }' | ConvertFrom-Json
+
+        # We should only approve pull requests that only contain commits from
+        # the GitHub user we expected and only commits that contain the metadata
+        # we need to determine what dependencies were updated by the other workflow.
+        $expectedUser = "${{ vars.UPDATER_COMMIT_USER_NAME }}"
+        $onlyDependencyUpdates = $True
+        $onlyChangesFromUser = $True
+
+        $dependencies = @()
+
+        foreach ($commit in $commits) {
+          if ($commit.Author -ne $expectedUser) {
+            # Some other commit is in the pull request
+            $onlyChangesFromUser = $False
+          }
+          # Extract the YAML metadata block from the commit message.
+          $match = [Regex]::Match($commit.Message, '(?m)^-{3}\s(?<dependencies>[\S|\s]*?)\s^\.{3}$')
+          if ($match.Success -eq $True) {
+            # Extract the names and update type from each dependency.
+            $metadata = ($match.Value | ConvertFrom-Yaml -Ordered)
+            $updates = $metadata["updated-dependencies"]
+            if ($updates) {
+              foreach ($update in $updates) {
+                $dependencies += @{
+                  Name = $update['dependency-name'];
+                  Type = $update['update-type'];
+                }
+              }
+            }
+          }
+          else {
+            # The pull request contains a commit that we didn't expect as the metadata is missing.
+            $onlyDependencyUpdates = $False
+          }
+        }
+
+        # Did we find at least one dependency?
+        $isPatch = $dependencies.Length -gt 0
+        $onlyTrusted = $dependencies.Length -gt 0
+        $trustedPackages = $env:INCLUDE_NUGET_PACKAGES.Split(',')
+
+        foreach ($dependency in $dependencies) {
+          $isPatch = $isPatch -And $dependency.Type -eq "version-update:semver-patch"
+          $onlyTrusted = $onlyTrusted -And
+            (
+              ($dependency.Name -eq "Microsoft.NET.Sdk") -Or
+              (($trustedPackages | Where-Object { $dependency.Name.StartsWith($_) }).Count -gt 0)
+            )
+        }
+
+        # We only trust the pull request to approve and auto-merge it
+        # if it only contains commits which change the .NET SDK and
+        # Microsoft-published NuGet packages that were made by the GitHub
+        # login we expect to make those changes in the other workflow.
+        $isTrusted = (($onlyTrusted -And $isPatch) -And $onlyChangesFromUser) -And $onlyDependencyUpdates
+        "is-trusted-update=$isTrusted" >> $env:GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # As long as it's not already approved, approve the pull request and enable auto-merge.
+      # Our CI tests coupled with required statuses should ensure that the changes compile
+      # and that the application is still functional after the update; any bug that might be
+      # introduced by the update should be caught by the tests. If that happens, the build
+      # workflow will fail and the preconditions for the auto-merge to happen won't be met.
+    - name: Approve pull request and enable auto-merge
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -eq 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr review --approve "$env:PR_URL"
+          gh pr merge --auto --squash "$env:PR_URL"
+        }
+        else {
+          Write-Host "PR already approved.";
+        }
+
+    # If something was present in the pull request that isn't expected, then disable
+    # auto-merge so that a human is required to look at the pull request and make a
+    # decision to merge it or not. This is to prevent the pull request from being merged
+    # automatically if there's an unexpected change introduced. Any existing review
+    # approvals that were made by the bot are also dismissed so human approval is required.
+    - name: Disable auto-merge and dismiss approvals
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -gt 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr merge --disable-auto "$env:PR_URL"
+          foreach ($approval in $approvals) {
+            gh api `
+              --method PUT `
+              /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$($approval.id)/dismissals `
+              -f message='Cannot approve as other changes have been introduced.' `
+              -f event='DISMISS'
+          }
+        }
+        else {
+          Write-Host "PR not already approved.";
+        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,16 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  NUGET_XMLDOC_MODE: skip
+  TERM: xterm
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }}
@@ -28,10 +38,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
 
     - name: Install StatsD
       shell: pwsh
@@ -50,32 +60,69 @@ jobs:
     - name: Build, Test and Package
       shell: pwsh
       run: ./build.ps1
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-        DOTNET_NO_LOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
-        NUGET_XMLDOC_MODE: skip
-        TERM: xterm
 
-    - uses: codecov/codecov-action@v3
-      name: Upload coverage to Codecov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # v3.1.3
       with:
         file: ./artifacts/coverage.net6.0.cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Publish artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: artifacts-${{ matrix.os_name }}
         path: ./artifacts
 
     - name: Publish NuGet packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/packages
 
+  validate-packages:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Validate NuGet packages
+      shell: pwsh
+      run: |
+        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
+        $invalidPackages = 0
+        foreach ($package in $packages) {
+          dotnet validate package local $package
+          if ($LASTEXITCODE -ne 0) {
+            $invalidPackages++
+          }
+        }
+        if ($invalidPackages -gt 0) {
+          Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
+        }
+
+  publish-nuget:
+    needs: validate-packages
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      startsWith(github.ref, 'refs/tags/v')
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
     - name: Push NuGet packages to NuGet.org
-      run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json
-      if: ${{ github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows' }}
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -1,0 +1,46 @@
+name: code-ql
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  code-ql:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,47 @@
+name: dependabot-approve
+
+on: pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    steps:
+
+      - name: Get dependabot metadata
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
+        id: dependabot-metadata
+
+      - name: Generate GitHub application token
+        id: generate-application-token
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+        with:
+          application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+          application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+          permissions: "contents:write, pull_requests:write"
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Approve pull request and enable auto-merge
+        shell: bash
+        if: |
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/checkout') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/dependency-review-action') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/download-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/upload-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action')
+        env:
+          GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr checkout "$PR_URL"
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@f46c48ed6d4f1227fb2d9ea62bf6bcbed315589e # v3.0.4

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,34 +1,21 @@
 name: update-dotnet-sdk
 
-env:
-  GIT_COMMIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-  GIT_COMMIT_USER_NAME: github-actions[bot]
-  TERM: xterm
-
 on:
   schedule:
-    - cron:  '30 09 * * MON-FRI'
     - cron:  '00 19 * * TUE'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  update-dotnet-sdk:
-    name: Update .NET SDK
-    runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update .NET SDK
-      id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@v2
-      with:
-        labels: "dependencies,.NET"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
-        user-name: ${{ env.GIT_COMMIT_USER_NAME }}
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@a9c7965f8619036551db9aaa4d6ff5e186ccd700 # v2.1.2
+    with:
+      labels: "dependencies,.NET"
+      update-nuget-packages: false
+      user-email: ${{ vars.UPDATER_COMMIT_USER_EMAIL }}
+      user-name: ${{ vars.UPDATER_COMMIT_USER_NAME }}
+    secrets:
+      application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
+      application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,79 @@
-# 3.0.0
+# CHANGELOG
 
-See https://github.com/justeat/JustEat.StatsD/releases/tag/v3.0.0.
+## 3.0.0
 
-# 2.1.0
+See <https://github.com/justeattakeaway/JustEat.StatsD/releases/tag/v3.0.0>.
 
-See https://github.com/justeat/JustEat.StatsD/releases/tag/v2.1.0.
+## 2.1.0
 
-# 2.0.0
+See <https://github.com/justeattakeaway/JustEat.StatsD/releases/tag/v2.1.0>.
 
-See https://github.com/justeat/JustEat.StatsD/releases/tag/v2.0.0.
+## 2.0.0
 
-# 1.1.0
+See <https://github.com/justeattakeaway/JustEat.StatsD/releases/tag/v2.0.0>.
+
+## 1.1.0
 
 Add support for .NET Core.
 
-# 1.0.4
-## Change
+## 1.0.4
+
+### Change
 
 Easy to use timers. Time a block of code with a `using` statement or time a lambda, with or without a return value. `async ... await` is also supported.
 
-usage: given an existing instance of `IStatsDPublisher` called `stats` you can do:
+Usage: given an existing instance of `IStatsDPublisher` called `stats` you can do:
 
 ```csharp
-    //  timing a block of code in a using statement:
-   using (stats.StartTimer("someStat"))
-   {
-      DoSomething();
-   }
+//  timing a block of code in a using statement:
+using (stats.StartTimer("someStat"))
+{
+    DoSomething();
+}
 
-   //  timing a lambda without a return value:
-   stats.Time("someStat", () => DoSomething());
+//  timing a lambda without a return value:
+stats.Time("someStat", () => DoSomething());
 
-    //  timing a lambda with a return value:
-    var result = stats.Time("someStat", () => GetSomething());
+//  timing a lambda with a return value:
+var result = stats.Time("someStat", () => GetSomething());
 
-    // works with async
-    using (stats.StartTimer("someStat"))
-    {
-        await DoSomethingAsync();
-    }
+// works with async
+using (stats.StartTimer("someStat"))
+{
+    await DoSomethingAsync();
+}
 
-    // and correctly times async lambdas using the usual syntax:
-    var result = await stats.Time("someStat", async () => await GetSomethingAsync());
-
+// and correctly times async lambdas using the usual syntax:
+var result = await stats.Time("someStat", async () => await GetSomethingAsync());
 ```
+
 The idea of "disposable timers" comes from [this StatsD client](https://github.com/Pereingo/statsd-csharp-client).
 
-# 1.0.3
-## Change
-Nuget metadata
+## 1.0.3
 
-# 1.0.2
-## Change
+### Changes
+
+NuGet metadata
+
+## 1.0.2
+
+### Changes
+
 * Move to Sys.Diag.Trace for logs to remove NLog dependency (so as to not force that on dependents)
 
-# 1.0.0
-## Add
+## 1.0.0
+
+### Add
+
 * We've been in production with this for a while now.  It deserves the 1.0 version tag.
 * Sort out references and dependencies such that nuget is relied upon.
 
-# 0.0.2
-## Add
+## 0.0.2
+
+### Add
+
 * Ability to prefix each stat, so the prefix/namespace can be supplied one-time via configuration rather than built each time a stat is pushed.  Eg, Mailman would want every stat to be prefixed with `{country}.mailman_{instance position}`
 
-# 0.0.1
+## 0.0.1
+
 * First release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team [through a GitHub issue](https://github.com/justeat/JustEat.StatsD/issues). All
+reported by contacting the project team [through a GitHub issue](https://github.com/justeattakeaway/JustEat.StatsD/issues). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/justeat/JustEat.StatsD</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/justeattakeaway/JustEat.StatsD</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](http://www.nuget.org/packages/JustEat.StatsD)
 
-[![Build status](https://github.com/justeat/JustEat.StatsD/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeat/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![Build status](https://github.com/justeattakeaway/JustEat.StatsD/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
 
-[![codecov](https://codecov.io/gh/justeat/JustEat.StatsD/branch/main/graph/badge.svg)](https://codecov.io/gh/justeat/JustEat.StatsD)
+[![codecov](https://codecov.io/gh/justeattakeaway/JustEat.StatsD/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/JustEat.StatsD)
 
 ## Summary
 
@@ -77,7 +77,7 @@ IStatsDPublisher statsDPublisher = new StatsDPublisher(statsDConfig);
 
 ### IoC Examples
 
-#### .NET Core
+#### .NET (Core)
 
 An example of registering StatsD dependencies using `IServiceCollection`:
 

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1001;CA1014;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CA1812
+
 using BenchmarkDotNet.Running;
 
 BenchmarkSwitcher


### PR DESCRIPTION
This PR makes a number of changes to GitHub actions to automate more of the repo maintenance and also hardens the repo against various recommendations that are made by the Open Source Software Foundation (OSSF) Scorecard.

The automation is based on [the approaches in this repository](https://github.com/martincostello/dotnet-patch-automation-sample/tree/main#readme).

Changes:

- Add a GitHub Actions workflow to run a CodeQL scan.
- Add a workflow to [review dependencies](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review).
- Validates the NuGet packages before publishing.
- Publish packages to NuGet as a separate job after the build.
- Harden GitHub workflows by pinning actions by Git SHA.
- Use [reusable workflow](https://github.com/martincostello/update-dotnet-sdk/tree/main#advanced-workflow) for updating the .NET SDK.
- Use a GitHub app to generate updates instead of `GITHUB_TOKEN` so that CI runs.
- Add a workflow to automatically approve and merge .NET SDK updates.
- Add a workflow to automatically approve and merge dependabot updates for GitHub-authored actions.
