### PR TITLE
Remove Moq

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Moq" Version="4.20.0" />
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="xunit" Version="2.5.0" />

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -48,7 +48,7 @@ internal sealed class BufferBasedStatsDPublisher : IStatsDPublisher
 
     private void SendMessage(double sampleRate, in StatsDMessage msg)
     {
-        bool shouldSendMessage = (sampleRate >= DefaultSampleRate || sampleRate > Random.NextDouble()) && msg.StatBucket != null;
+        bool shouldSendMessage = (sampleRate >= DefaultSampleRate || sampleRate > Random.NextDouble()) && msg.StatBucket != null && msg.StatBucket.Length > 0;
 
         if (!shouldSendMessage)
         {

--- a/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD.Buffered;
 
@@ -9,15 +9,15 @@ public static class BufferBasedStatsDPublisherTests
     {
         // Arrange
         var configuration = new StatsDConfiguration();
-        var transport = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
-        var publisher = new BufferBasedStatsDPublisher(configuration, transport.Object);
+        var publisher = new BufferBasedStatsDPublisher(configuration, transport);
 
         // Act
         publisher.Increment(1, 1, null!, null);
 
         // Assert
-        transport.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Never());
+        transport.DidNotReceiveWithAnyArgs().Send(default);
     }
 
     [Fact]
@@ -25,14 +25,14 @@ public static class BufferBasedStatsDPublisherTests
     {
         // Arrange
         var configuration = new StatsDConfiguration() { Prefix = new string('a', 513) };
-        var transport = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
-        var publisher = new BufferBasedStatsDPublisher(configuration, transport.Object);
+        var publisher = new BufferBasedStatsDPublisher(configuration, transport);
 
         // Act
         publisher.Increment(1, 1, "foo");
 
         // Assert
-        transport.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Once());
+        transport.ReceivedWithAnyArgs(1).Send(default);
     }
 }

--- a/tests/JustEat.StatsD.Tests/IStatsDTransportExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/IStatsDTransportExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD;
 
@@ -30,7 +30,7 @@ public static class IStatsDTransportExtensionsTests
     public static void SendThrowsIfTransportIfMetricIsNull()
     {
         // Arrange
-        var transport = Mock.Of<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         string? metric = null;
 
         // Act and Assert
@@ -41,7 +41,7 @@ public static class IStatsDTransportExtensionsTests
     public static void SendThrowsIfMetricsIsNull()
     {
         // Arrange
-        var transport = Mock.Of<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         IEnumerable<string>? metrics = null;
 
         // Act and Assert
@@ -52,27 +52,27 @@ public static class IStatsDTransportExtensionsTests
     public static void SendSendsStringMetric()
     {
         // Arrange
-        var transport = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         string metric = "metric";
 
         // Act
-        transport.Object.Send(metric);
+        transport.Send(metric);
 
         // Assert
-        transport.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Once());
+        transport.ReceivedWithAnyArgs(1).Send(default);
     }
 
     [Fact]
     public static void SendSendsStringMetrics()
     {
         // Arrange
-        var transport = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         var metrics = new[] { "a", "b", "c" };
 
         // Act
-        transport.Object.Send(metrics);
+        transport.Send(metrics);
 
         // Assert
-        transport.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(3));
+        transport.ReceivedWithAnyArgs(3).Send(default);
     }
 }

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
+++ b/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using JustEat.StatsD.EndpointLookups;
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD;
 
@@ -68,7 +68,8 @@ public static class SocketTransportTests
     [Fact]
     public static void SocketTransportIsNoopForNullEndpoint()
     {
-        var endpointSource = Mock.Of<IEndPointSource>();
+        var endpointSource = Substitute.For<IEndPointSource>();
+        endpointSource.GetEndpoint().Returns(null as EndPoint);
 
         using var transport = new SocketTransport(endpointSource, SocketProtocol.IP);
         transport.Send("teststat:1|c");

--- a/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD;
 
@@ -8,14 +8,14 @@ public static class StatsDPublisherTests
     public static void Decrement_Sends_Multiple_Metrics()
     {
         // Arrange
-        var mock = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
         var config = new StatsDConfiguration
         {
             Prefix = "red",
         };
 
-        using (var publisher = new StatsDPublisher(config, mock.Object))
+        using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
             publisher.Decrement(10, "black");
@@ -27,21 +27,21 @@ public static class StatsDPublisherTests
         }
 
         // Assert
-        mock.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(8));
+        transport.ReceivedWithAnyArgs(8).Send(default);
     }
 
     [Fact]
     public static void Increment_Sends_Multiple_Metrics()
     {
         // Arrange
-        var mock = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
         var config = new StatsDConfiguration
         {
             Prefix = "red",
         };
 
-        using (var publisher = new StatsDPublisher(config, mock.Object))
+        using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
             publisher.Increment(10, "black");
@@ -53,21 +53,21 @@ public static class StatsDPublisherTests
         }
 
         // Assert
-        mock.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(8));
+        transport.ReceivedWithAnyArgs(8).Send(default);
     }
 
     [Fact]
     public static void Metrics_Sent_If_Tags_Are_Null()
     {
         // Arrange
-        var mock = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
         var config = new StatsDConfiguration
         {
             Prefix = "red",
         };
 
-        using (var publisher = new StatsDPublisher(config, mock.Object))
+        using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
             publisher.Increment(10, 1.0, "black");
@@ -76,14 +76,14 @@ public static class StatsDPublisherTests
         }
 
         // Assert
-        mock.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(3));
+        transport.ReceivedWithAnyArgs(3).Send(default);
     }
 
     [Fact]
     public static void Metrics_Not_Sent_If_Array_Is_Null_Or_Empty()
     {
         // Arrange
-        var mock = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         var config = new StatsDConfiguration();
         var anyValidTags = new Dictionary<string, string?>
         {
@@ -92,7 +92,7 @@ public static class StatsDPublisherTests
             ["lorem"] = "ipsum",
         };
 
-        using (var publisher = new StatsDPublisher(config, mock.Object))
+        using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
 #nullable disable
@@ -120,17 +120,17 @@ public static class StatsDPublisherTests
         }
 
         // Assert
-        mock.Verify((p) => p.Send(It.IsAny<ArraySegment<byte>>()), Times.Never());
+        transport.DidNotReceiveWithAnyArgs().Send(default);
     }
 
     [Fact]
     public static void Metrics_Not_Sent_If_No_Metrics()
     {
         // Arrange
-        var mock = new Mock<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
         var config = new StatsDConfiguration();
 
-        using (var publisher = new StatsDPublisher(config, mock.Object))
+        using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
             publisher.Decrement(1, 0, new[] { "foo" });
@@ -138,7 +138,7 @@ public static class StatsDPublisherTests
         }
 
         // Assert
-        mock.Verify((p) => p.Send(It.IsAny<ArraySegment<byte>>()), Times.Never());
+        transport.DidNotReceiveWithAnyArgs().Send(default);
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public static class StatsDPublisherTests
     {
         // Arrange
         StatsDConfiguration? configuration = null;
-        var transport = Mock.Of<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
         // Act and Assert
         Assert.Throws<ArgumentNullException>(
@@ -175,7 +175,7 @@ public static class StatsDPublisherTests
         {
             TagsFormatter = null!,
         };
-        var transport = Mock.Of<IStatsDTransport>();
+        var transport = Substitute.For<IStatsDTransport>();
 
         // Act
         using var publisher = new StatsDPublisher(configuration, transport);

--- a/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD;
 
@@ -19,7 +19,7 @@ public static class TimerExtensionsTests
     public static void TimeThrowsIfActionIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Action? action = null;
@@ -32,7 +32,7 @@ public static class TimerExtensionsTests
     public static void TimeThrowsIfActionForTimerIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Action<IDisposableTimer>? action = null;
@@ -45,7 +45,7 @@ public static class TimerExtensionsTests
     public static async Task TimeThrowsIfFuncForTaskIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<Task>? action = null;
@@ -58,7 +58,7 @@ public static class TimerExtensionsTests
     public static async Task TimeThrowsIfFuncForTaskWithTimerIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<IDisposableTimer, Task>? action = null;
@@ -71,7 +71,7 @@ public static class TimerExtensionsTests
     public static void TimeThrowsIfFuncOfTIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<int>? func = null;
@@ -84,7 +84,7 @@ public static class TimerExtensionsTests
     public static void TimeThrowsIfFuncOfTWithTimerIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<IDisposableTimer, int>? func = null;
@@ -97,7 +97,7 @@ public static class TimerExtensionsTests
     public static async Task TimeThrowsIfFuncForTaskOfTIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<Task<int>>? func = null;
@@ -110,7 +110,7 @@ public static class TimerExtensionsTests
     public static async Task TimeThrowsIfFuncForTaskOfTWithTimerIsNull()
     {
         // Arrange
-        var publisher = Mock.Of<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         Func<IDisposableTimer, Task<int>>? func = null;
@@ -123,31 +123,28 @@ public static class TimerExtensionsTests
     public static void CanTimeAction()
     {
         // Arrange
-        var publisher = new Mock<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         bool timed = false;
 
         // Act
-        publisher.Object.Time(bucket, () => { timed = true; });
+        publisher.Time(bucket, () => { timed = true; });
 
         // Assert
         timed.ShouldBeTrue();
-        publisher.Verify(
-            (p) => p.Timing(It.IsAny<long>(), 1, bucket,
-                It.IsAny<Dictionary<string, string?>>()),
-                Times.Once());
+        publisher.Received(1).Timing(Arg.Any<long>(), 1, bucket, Arg.Any<Dictionary<string, string?>>());
     }
 
     [Fact]
     public static void CanTimeActionWithTimerOfT()
     {
         // Arrange
-        var publisher = new Mock<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         // Act
-        int actual = publisher.Object.Time(
+        int actual = publisher.Time(
             bucket,
             (timer) =>
             {
@@ -159,23 +156,20 @@ public static class TimerExtensionsTests
 
         // Assert
         actual.ShouldBe(42);
-        publisher.Verify(
-            (p) => p.Timing(It.IsAny<long>(), 1, bucket,
-                It.IsAny<Dictionary<string, string?>>()),
-                Times.Once());
+        publisher.Received(1).Timing(Arg.Any<long>(), 1, bucket, Arg.Any<Dictionary<string, string?>>());
     }
 
     [Fact]
     public static async Task CanTimeAsyncActionWithTimerOfT()
     {
         // Arrange
-        var publisher = new Mock<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         bool timed = false;
 
         // Act
-        await publisher.Object.Time(
+        await publisher.Time(
             bucket,
             (timer) =>
             {
@@ -189,21 +183,18 @@ public static class TimerExtensionsTests
 
         // Assert
         timed.ShouldBeTrue();
-        publisher.Verify(
-            (p) => p.Timing(It.IsAny<long>(), 1, bucket,
-                It.IsAny<Dictionary<string, string?>>()),
-                Times.Once());
+        publisher.Received(1).Timing(Arg.Any<long>(), 1, bucket, Arg.Any<Dictionary<string, string?>>());
     }
 
     [Fact]
     public static async Task CanTimeAsyncFuncWithTimerOfT()
     {
         // Arrange
-        var publisher = new Mock<IStatsDPublisher>();
+        var publisher = Substitute.For<IStatsDPublisher>();
         string bucket = "bucket";
 
         // Act
-        int actual = await publisher.Object.Time(
+        int actual = await publisher.Time(
             bucket,
             (timer) =>
             {
@@ -215,9 +206,6 @@ public static class TimerExtensionsTests
 
         // Assert
         actual.ShouldBe(42);
-        publisher.Verify(
-            (p) => p.Timing(It.IsAny<long>(), 1, bucket,
-                It.IsAny<Dictionary<string, string?>>()),
-                Times.Once());
+        publisher.Received(1).Timing(Arg.Any<long>(), 1, bucket, Arg.Any<Dictionary<string, string?>>());
     }
 }

--- a/tests/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/tests/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -1,6 +1,6 @@
 using JustEat.StatsD.EndpointLookups;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 
 namespace JustEat.StatsD;
 
@@ -189,9 +189,9 @@ public static class WhenRegisteringStatsD
     {
         // Arrange
         var existingConfig = new StatsDConfiguration();
-        var existingSource = Mock.Of<IEndPointSource>();
-        var existingTransport = Mock.Of<IStatsDTransport>();
-        var existingPublisher = Mock.Of<IStatsDPublisher>();
+        var existingSource = Substitute.For<IEndPointSource>();
+        var existingTransport = Substitute.For<IStatsDTransport>();
+        var existingPublisher = Substitute.For<IStatsDPublisher>();
 
         var provider = Configure(services =>
             {


### PR DESCRIPTION
- Remove Moq and replace with NSubstitute.
- Fix a bug masked by Moq where we were sending empty buckets.
- Use C#10, rather than 11, to resolve warnings I don't know how to fix related to the new `scoped` keyword (see https://github.com/justeattakeaway/JustEat.StatsD/pull/374#issuecomment-1306112406).
