### PR TITLE
Use HTTPS for NuGet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JustEat.StatsD
 
-[![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](http://www.nuget.org/packages/JustEat.StatsD)
+[![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](https://www.nuget.org/packages/JustEat.StatsD)
 [![Build status](https://github.com/justeattakeaway/JustEat.StatsD/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
 
 [![codecov](https://codecov.io/gh/justeattakeaway/JustEat.StatsD/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/JustEat.StatsD)


### PR DESCRIPTION
Use HTTPS not HTTP to link to the NuGet package.
