### PR TITLE
Bump version back to 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We use this library within our components to publish [StatsD](http://github.com/
 
 ### Supported platforms
 
-`JustEat.StatsD` version 4.2.0 is built for these target frameworks:
+`JustEat.StatsD` version 5.0.0 is built for these target frameworks:
 
 * `net462`
 * `netstandard2.0`

--- a/build.ps1
+++ b/build.ps1
@@ -9,6 +9,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
+$env:MSBUILDTERMINALLOGGER = "auto"
 
 $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -5,6 +5,7 @@
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
     <OutputType>Library</OutputType>
     <PackageId>JustEat.StatsD</PackageId>
+    <!-- TODO Bump to 5.0.0 post-release -->
     <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <Summary>A .NET library for publishing metrics to StatsD.</Summary>

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <VersionPrefix>4.3.0</VersionPrefix>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>


### PR DESCRIPTION
We dropped several TFMs since the last release, so we still need to bump the major version even with the changes in #416.

```diff
- <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
+ <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
```

Alternatively, if we still want to release as 4.3.0 then do a different PR to put them back.

Thoughts?
