### PR TITLE
Add dedicated package README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please submit any feature requests or bugs as an [issue](https://github.com/just
 
 ## Pull requests
 
-The easier your PRs are to review and merge, the more likely your contribution will be accepted. :-)
+The easier your PRs are to review and merge, the more likely your contribution will be accepted.
 
 If you wish to contribute code, please consider the guidelines below:
 
@@ -14,7 +14,7 @@ If you wish to contribute code, please consider the guidelines below:
 1. Fork the repository to your GitHub account.
 1. Create a branch to work on your changes.
 1. Try to commit changes in a logical manner. Messy histories will be squashed if merged.
-1. Please follow the existing code style and [EditorConfig](http://editorconfig.org/) formatting settings so that your file touches are consistent with ours and the diff is reduced.
+1. Please follow the existing code style and [EditorConfig](https://editorconfig.org/) formatting settings so that your file touches are consistent with ours and the diff is reduced.
 1. If fixing a bug or adding new functionality, add any tests you deem appropriate.
 1. Test coverage should not go down.
 1. Note any breaking changes in your PR description.
@@ -27,7 +27,7 @@ If the project maintainers are satisfied that your contribution is appropriate i
 
 ## Releases
 
-* Check the version number has been updated since the last release - follow [SemVer rules](http://semver.org)
+* Check the version number has been updated since the last release - follow [SemVer rules](https://semver.org)
   * Bump the version in `version.props` if neccessary.
 * Update the CHANGELOG.md
 * Create a new release in [GitHub](https://github.com/justeattakeaway/JustEat.StatsD/releases) with appropriate release notes and tagged version number (for example `v1.2.3`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeattakeaway/JustEat.StatsD</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>statsd,graphite,metrics,monitoring</PackageTags>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,11 +192,11 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-We use this library within our components to publish [StatsD](http://github.com/etsy/statsd) metrics from .NET code to a server. We've been using this in most of our things, since around 2013.
+We use this library within our components to publish [StatsD](https://github.com/etsy/statsd) metrics from .NET code to a server. We've been using this in most of our things, since around 2013.
 
 ### Supported platforms
 

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,29 @@
+# JustEat.StatsD
+
+[![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](https://www.nuget.org/packages/JustEat.StatsD)
+[![Build status](https://github.com/justeattakeaway/JustEat.StatsD/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![codecov](https://codecov.io/gh/justeattakeaway/JustEat.StatsD/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/JustEat.StatsD)
+
+## Summary
+
+A library to publish [StatsD](https://github.com/etsy/statsd) metrics from .NET applications to a server.
+
+## Features
+
+* Easy to use.
+* Robust and proven.
+* Tuned for high performance and low resource usage.
+* Supports standard StatsD primitives: `Increment`, `Decrement`, `Timing` and `Gauge`.
+* Supports tagging on `Increment`, `Decrement`, `Timing` and `Gauge`.
+* Supports sampling for cutting down of sends of high-volume metrics.
+* Helpers to make it easy to time a delegate such as a `Func<T>` or `Action<T>`, or a code block inside a `using` statement.
+* Send stats over UDP or IP.
+* Send stats to a server by name or IP address.
+
+## Feedback
+
+Any feedback or issues for this library can be added to the issues in [GitHub](https://github.com/justeattakeaway/JustEat.StatsD/issues "This package's issues on GitHub.com").
+
+## License
+
+This package is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html "The Apache 2.0 license") license.


### PR DESCRIPTION
NuGet.org's content security policy and reduced Markdown rendering support mean that the [project README doesn't render well as it could](https://www.nuget.org/packages/JustEat.StatsD#readme-body-tab) in the NuGet gallery. Instead, add a dedicated package README with pared-back information that will render better and is more context-specific.

Also updates some links from HTTP to HTTPS.
