### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: false
 
     permissions:
-      contents: read
+      contents: write
       issues: write
 
     steps:


### PR DESCRIPTION
Write access is needed to generate release notes.

See https://github.com/justeattakeaway/httpclient-interception/pull/781.
