### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: |
-          ./artifacts/publish/JustEat.StatsD/release*/JustEat.StatsD.dll
+          ./artifacts/bin/JustEat.StatsD/release*/JustEat.StatsD.dll
           ./artifacts/package/release/*
 
     - name: Publish artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
 
     strategy:
@@ -37,11 +37,11 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:
           - os: macos-latest
-            os_name: macos
+            os-name: macos
           - os: ubuntu-latest
-            os_name: linux
+            os-name: linux
           - os: windows-latest
-            os_name: windows
+            os-name: windows
 
     steps:
 
@@ -74,8 +74,16 @@ jobs:
       uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
       with:
         file: ./artifacts/coverage/coverage.net8.0.cobertura.xml
-        flags: ${{ matrix.os_name }}
+        flags: ${{ matrix.os-name }}
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Generate SBOM
+      uses: anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
+      with:
+        artifact-name: build-${{ matrix.os-name }}.spdx.json
+        output-file: ./artifacts/build.spdx.json
+        path: ./artifacts/bin
+        upload-release-assets: ${{ runner.os == 'Windows' }}
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
@@ -91,13 +99,13 @@ jobs:
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: artifacts-${{ matrix.os_name }}
+        name: artifacts-${{ matrix.os-name }}
         path: ./artifacts
 
     - name: Publish NuGet packages
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: packages-${{ matrix.os_name }}
+        name: packages-${{ matrix.os-name }}
         path: ./artifacts/package/release
         if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +76,17 @@ jobs:
         file: ./artifacts/coverage/coverage.net8.0.cobertura.xml
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      if: |
+        runner.os == 'Windows' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        subject-path: |
+          ./artifacts/publish/JustEat.StatsD/release*/JustEat.StatsD.dll
+          ./artifacts/package/release/*
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
- Attest the binaries and packages from the build artifacts.
- Generate an SBOM from the build, and attach it to any releases.
