### PR TITLE
Remove build from CodeQL

### DIFF
--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -29,18 +29,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-
     - name: Initialize CodeQL
       uses: github/codeql-action/init@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
       with:
+        build-mode: none
         languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
       with:
-        category: "/language:${{ matrix.language }}"
+        category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Analyse C# code without building it [which is now supported by CodeQL 2.17.6+](https://github.blog/changelog/2024-07-26-codeql-2-18-1-kotlin-swift-mobile-support-is-generally-available-typescript-5-5-support-c-build-mode-none-public-beta/).
