### PR TITLE
Update to xunit v3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,6 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,9 +11,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.3" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="xunit.v3" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageVersion Include="System.Memory" Version="4.5.1" />

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -3,6 +3,7 @@
     <Description>A .NET library for publishing metrics to StatsD.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+    <LangVersion>10</LangVersion>
     <OutputType>Library</OutputType>
     <PackageId>JustEat.StatsD</PackageId>
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/CachedEndpointSourceTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/CachedEndpointSourceTests.cs
@@ -50,7 +50,7 @@ public static class CachedEndpointSourceTests
         cachedEndpoint.GetEndpoint();
         cachedEndpoint.GetEndpoint();
 
-        await Task.Delay(1500);
+        await Task.Delay(TimeSpan.FromSeconds(1.5), TestContext.Current.CancellationToken);
 
         cachedEndpoint.GetEndpoint();
         cachedEndpoint.GetEndpoint();
@@ -86,6 +86,6 @@ public static class CachedEndpointSourceTests
 
     private static IPEndPoint MakeTestIpEndPoint()
     {
-        return new IPEndPoint(new IPAddress(new byte[] { 1, 2, 3, 4 }), 8125);
+        return new IPEndPoint(new IPAddress([1, 2, 3, 4]), 8125);
     }
 }

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
@@ -11,7 +11,7 @@ public static class EndPointFactoryTests
 
         parsed.ShouldNotBeNull();
 
-        var expected = new IPEndPoint(new IPAddress(new byte[] { 11, 12, 13, 14 }), 8125);
+        var expected = new IPEndPoint(new IPAddress([11, 12, 13, 14]), 8125);
         parsed.GetEndpoint().ShouldBe(expected);
     }
 

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/SimpleEndpointTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/SimpleEndpointTests.cs
@@ -33,6 +33,6 @@ public static class SimpleEndpointTests
 
     private static IPEndPoint MakeTestIpEndPoint()
     {
-        return new IPEndPoint(new IPAddress(new byte[] { 1, 2, 3, 4 }), 8125);
+        return new IPEndPoint(new IPAddress([1, 2, 3, 4]), 8125);
     }
 }

--- a/tests/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/tests/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -6,7 +6,7 @@ namespace JustEat.StatsD;
 
 public static class IntegrationTests
 {
-    [SkippableTheory]
+    [Theory]
     [InlineData("localhost", SocketProtocol.IP)]
     [InlineData("localhost", SocketProtocol.Udp)]
     [InlineData("localhost", SocketProtocol.Tcp)]
@@ -17,7 +17,7 @@ public static class IntegrationTests
         string host,
         SocketProtocol socketProtocol)
     {
-        Skip.If(Environment.GetEnvironmentVariable("CI") == null, "By default, this test is only run during continuous integration.");
+        Assert.SkipWhen(Environment.GetEnvironmentVariable("CI") is null, "By default, this test is only run during continuous integration.");
 
         // Arrange
         var config = new StatsDConfiguration
@@ -63,9 +63,9 @@ public static class IntegrationTests
         publisher.Timing(TimeSpan.FromSeconds(3.5), 1, "hen");
 
         // Act - Increment multiple counters
-        publisher.Increment(7, 1, new string[] { "green", "red" });       // 7
+        publisher.Increment(7, 1, ["green", "red"]);       // 7
         publisher.Increment(2, 0, new List<string>() { "green", "red" }); // 7
-        publisher.Decrement(1, 0, new string[] { "red", "green" });       // 7
+        publisher.Decrement(1, 0, ["red", "green"]);       // 7
         publisher.Decrement(4, 1, new List<string>() { "red", "green" }); // 3
 
         // Allow enough time for metrics to be registered
@@ -84,10 +84,10 @@ public static class IntegrationTests
         result.Value<int>(config.Prefix + ".dog").ShouldBe(42, result.ToString());
 
         result = await SendCommandAsync("timers");
-        result[config.Prefix + ".elephant"]!.Values<int>().ShouldBe(new[] { 123 }, result.ToString());
-        result[config.Prefix + ".fox"]!.Values<int>().ShouldBe(new[] { 2000 }, result.ToString());
-        result[config.Prefix + ".goose"]!.Values<int>().ShouldBe(new[] { 456 }, result.ToString());
-        result[config.Prefix + ".hen"]!.Values<int>().ShouldBe(new[] { 3500 }, result.ToString());
+        result[config.Prefix + ".elephant"]!.Values<int>().ShouldBe([123], result.ToString());
+        result[config.Prefix + ".fox"]!.Values<int>().ShouldBe([2000], result.ToString());
+        result[config.Prefix + ".goose"]!.Values<int>().ShouldBe([456], result.ToString());
+        result[config.Prefix + ".hen"]!.Values<int>().ShouldBe([3500], result.ToString());
     }
 
     private static async Task<JObject> SendCommandAsync(string command)

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1014;CA1002;CA1861;CA1707;CA1711;CA2007</NoWarn>
+    <OutputType>Exe</OutputType>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
@@ -15,15 +16,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Shouldly" />
     <Using Include="Xunit" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
@@ -22,7 +22,7 @@ public static class StatsDPublisherTests
             publisher.Decrement(-10, "yellow");
             publisher.Decrement(10, 1, "pink");
             publisher.Decrement(-10, 1, "orange");
-            publisher.Decrement(10, 1, new[] { "white", "blue" });
+            publisher.Decrement(10, 1, ["white", "blue"]);
             publisher.Decrement(10, 1, new List<string>() { "green", "red" });
         }
 
@@ -48,7 +48,7 @@ public static class StatsDPublisherTests
             publisher.Increment(-10, "yellow");
             publisher.Increment(10, 1, "pink");
             publisher.Increment(-10, 1, "orange");
-            publisher.Increment(10, 1, new[] { "white", "blue" });
+            publisher.Increment(10, 1, ["white", "blue"]);
             publisher.Increment(10, 1, new List<string>() { "green", "red" });
         }
 
@@ -108,12 +108,12 @@ public static class StatsDPublisherTests
             publisher.Increment(-1, 1, new List<string>());
             publisher.Decrement(1, 1, null as IEnumerable<string>);
             publisher.Increment(1, 1, null as IEnumerable<string>);
-            publisher.Decrement(1, 1, new[] { string.Empty });
-            publisher.Increment(1, 1, new[] { string.Empty });
-            publisher.Decrement(1, 1, new[] { string.Empty }, anyValidTags);
-            publisher.Increment(1, 1, new[] { string.Empty }, anyValidTags);
-            publisher.Decrement(1, 1, anyValidTags, new[] { string.Empty });
-            publisher.Increment(1, 1, anyValidTags, new[] { string.Empty });
+            publisher.Decrement(1, 1, [string.Empty]);
+            publisher.Increment(1, 1, [string.Empty]);
+            publisher.Decrement(1, 1, [string.Empty], anyValidTags);
+            publisher.Increment(1, 1, [string.Empty], anyValidTags);
+            publisher.Decrement(1, 1, anyValidTags, [string.Empty]);
+            publisher.Increment(1, 1, anyValidTags, [string.Empty]);
             publisher.Decrement(1, 1, anyValidTags, null as string[]);
             publisher.Increment(1, 1, anyValidTags, null as string[]);
 #nullable enable
@@ -133,8 +133,8 @@ public static class StatsDPublisherTests
         using (var publisher = new StatsDPublisher(config, transport))
         {
             // Act
-            publisher.Decrement(1, 0, new[] { "foo" });
-            publisher.Increment(1, 0, new[] { "bar" });
+            publisher.Decrement(1, 0, ["foo"]);
+            publisher.Increment(1, 0, ["bar"]);
         }
 
         // Assert


### PR DESCRIPTION
- Update to xunit v3.
- Use latest version of C# everywhere except the library.
- Use collection expressions in tests where relevant.
