### PR TITLE
Add GraphiteDB tags formatter

### DIFF
--- a/src/JustEat.StatsD/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Shipped.txt
@@ -118,6 +118,7 @@ static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft
 static JustEat.StatsD.TagsFormatter.CloudWatch.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.DataDog.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.InfluxDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.GraphiteDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.Librato.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.SignalFx.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.Splunk.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!

--- a/src/JustEat.StatsD/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Shipped.txt
@@ -118,7 +118,6 @@ static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft
 static JustEat.StatsD.TagsFormatter.CloudWatch.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.DataDog.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.InfluxDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
-static JustEat.StatsD.TagsFormatter.GraphiteDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.Librato.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.SignalFx.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
 static JustEat.StatsD.TagsFormatter.Splunk.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!

--- a/src/JustEat.StatsD/PublicAPI.Unshipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static JustEat.StatsD.TagsFormatter.GraphiteDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!

--- a/src/JustEat.StatsD/TagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatter.cs
@@ -18,6 +18,11 @@ public static class TagsFormatter
     public static IStatsDTagsFormatter DataDog => new TrailingTagsFormatter();
 
     /// <summary>
+    /// Gets a GraphiteDB tags formatter.
+    /// </summary>
+    public static IStatsDTagsFormatter GraphiteDb => new GraphiteDbTagsFormatter();
+
+    /// <summary>
     /// Gets an InfluxDB tags formatter.
     /// </summary>
     public static IStatsDTagsFormatter InfluxDb => new InfluxDbTagsFormatter();

--- a/src/JustEat.StatsD/TagsFormatters/GraphiteDbTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/GraphiteDbTagsFormatter.cs
@@ -1,0 +1,28 @@
+namespace JustEat.StatsD.TagsFormatters;
+
+/// <summary>
+/// Formats StatsD tags for GraphiteDB.
+/// Tags placed right after the bucket name with format: <code>";" + tag1=value1;tag2;tag3=value</code>.
+/// </summary>
+internal sealed class GraphiteDbTagsFormatter : StatsDTagsFormatter
+{
+    private const string Prefix = ";";
+    private const bool AreTrailingTags = false;
+    private const string TagsSeparator = ";";
+    private const string KeyValueSeparator = "=";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphiteDbTagsFormatter"/> class.
+    /// </summary>
+    public GraphiteDbTagsFormatter()
+        : base(new StatsDTagsFormatterConfiguration
+        {
+            Prefix = Prefix,
+            Suffix = string.Empty,
+            AreTrailing = AreTrailingTags,
+            TagsSeparator = TagsSeparator,
+            KeyValueSeparator = KeyValueSeparator,
+        })
+    {
+    }
+}

--- a/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
+++ b/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
@@ -18,11 +18,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|c|@0.5")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|c|@0.5|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c|@0.5")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|c|@0.5")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c|@0.5")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c|@0.5")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|c|@0.5\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|c|@0.5|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c|@0.5\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|c|@0.5\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c|@0.5\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c|@0.5\n")]
     public static void CounterSampled(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -35,11 +37,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|c")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|c|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|c")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|c\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|c|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|c\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c\n")]
     public static void CounterRegular(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -52,11 +56,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:-128|c")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:-128|c|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:-128|c")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:-128|c")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:-128|c")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:-128|c")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:-128|c\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:-128|c|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:-128|c\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:-128|c\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:-128|c\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:-128|c\n")]
     public static void CounterNegative(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -69,11 +75,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|c")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|c")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket:128|c")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket:128|c")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket:128|c")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket:128|c")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|c\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|c\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket:128|c\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket:128|c\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket:128|c\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket:128|c\n")]
     public static void CounterWithoutTags(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -86,11 +94,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|ms")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|ms|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|ms")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|ms\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|ms|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|ms\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms\n")]
     public static void Timing(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -103,11 +113,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|ms|@0.5")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|ms|@0.5|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms|@0.5")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|ms|@0.5")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms|@0.5")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms|@0.5")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|ms|@0.5\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|ms|@0.5|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms|@0.5\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|ms|@0.5\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms|@0.5\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms|@0.5\n")]
     public static void TimingSampled(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -120,11 +132,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128|g")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128|g|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|g")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|g")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|g")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|g")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128|g\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128|g|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|g\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128|g\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|g\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|g\n")]
     public static void GaugeIntegral(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -137,11 +151,13 @@ public static class Utf8TagsFormatterTests
     [InlineData(false, TagsFormatter.NoOp, "prefix.bucket:128.5|g")]
     [InlineData(false, TagsFormatter.Trailing, "prefix.bucket:128.5|g|#foo:bar,empty,lorem:ipsum")]
     [InlineData(false, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128.5|g")]
+    [InlineData(false, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128.5|g")]
     [InlineData(false, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128.5|g")]
     [InlineData(false, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128.5|g")]
     [InlineData(true, TagsFormatter.NoOp, "prefix.bucket:128.5|g\n")]
     [InlineData(true, TagsFormatter.Trailing, "prefix.bucket:128.5|g|#foo:bar,empty,lorem:ipsum\n")]
     [InlineData(true, TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128.5|g\n")]
+    [InlineData(true, TagsFormatter.GraphiteDb, "prefix.bucket;foo=bar;empty;lorem=ipsum:128.5|g\n")]
     [InlineData(true, TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128.5|g\n")]
     [InlineData(true, TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128.5|g\n")]
     public static void GaugeFloat(bool formatterEndWithLineFeedSymbol, TagsFormatter tagsFormatter, string expected)
@@ -303,6 +319,7 @@ public static class Utf8TagsFormatterTests
             TagsFormatter.NoOp => new NoOpTagsFormatter(),
             TagsFormatter.Trailing => JustEat.StatsD.TagsFormatter.CloudWatch,
             TagsFormatter.InfluxDb => JustEat.StatsD.TagsFormatter.InfluxDb,
+            TagsFormatter.GraphiteDb => JustEat.StatsD.TagsFormatter.GraphiteDb,
             TagsFormatter.Librato => JustEat.StatsD.TagsFormatter.Librato,
             TagsFormatter.SignalFx => JustEat.StatsD.TagsFormatter.SignalFx,
             _ => throw new ArgumentOutOfRangeException(nameof(tagsFormatter))
@@ -321,6 +338,7 @@ public static class Utf8TagsFormatterTests
         NoOp,
         Trailing,
         InfluxDb,
+        GraphiteDb,
         Librato,
         SignalFx,
     }

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <VersionPrefix>5.0.2</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>


### PR DESCRIPTION
# Add GraphiteDB Tags Formatter

## Description
Add support for GraphiteDB tags formatting in StatsD metrics. The new formatter allows tags to be placed right after the bucket name using GraphiteDB's specific format: `;tag1=value1;tag2;tag3=value3`.

## Changes
- Add new `GraphiteDbTagsFormatter` class implementing StatsD tags formatting for GraphiteDB
- Add corresponding unit tests to validate the formatter behavior
- The formatter uses the following configuration:
  - Prefix: ";"
  - No suffix
  - Tags are placed immediately after metric name (non-trailing)
  - Tags separator: ";"
  - Key-value separator: "="

## Example Outputs
```text
# Counter with tags
prefix.bucket;foo=bar;empty;lorem=ipsum:128|c

# Timing with tags and sampling rate
prefix.bucket;foo=bar;empty;lorem=ipsum:128|ms|@0.5

# Gauge with floating point value
prefix.bucket;foo=bar;empty;lorem=ipsum:128.5|g